### PR TITLE
fix: Content Type case sensitivity

### DIFF
--- a/lambda/parse-request-body.ts
+++ b/lambda/parse-request-body.ts
@@ -17,7 +17,7 @@ import { bodySchema, CONTENT_TYPES, headersSchema } from './schema';
 
 export function parseRequestBody(body: string, headers: IncomingHttpHeaders) {
   const headersResult = headersSchema.parse(headers);
-  const contentType = headersResult['content-type'];
+  const contentType = headersResult['content-type'] || headersResult['Content-Type'] || undefined;
   switch (contentType) {
     case CONTENT_TYPES.JSON:
       return JSON.parse(body);

--- a/lambda/parse-request-body.ts
+++ b/lambda/parse-request-body.ts
@@ -17,7 +17,7 @@ import { bodySchema, CONTENT_TYPES, headersSchema } from './schema';
 
 export function parseRequestBody(body: string, headers: IncomingHttpHeaders) {
   const headersResult = headersSchema.parse(headers);
-  const contentType = headersResult['content-type'] || headersResult['Content-Type'] || undefined;
+  const contentType = headersResult['content-type'] || headersResult['Content-Type'];
   switch (contentType) {
     case CONTENT_TYPES.JSON:
       return JSON.parse(body);

--- a/lambda/proxy.test.ts
+++ b/lambda/proxy.test.ts
@@ -117,7 +117,7 @@ describe('proxy', () => {
     expect(axios.post).toHaveBeenCalled();
   });
 
-  it('should forward a request if content-type header is Content-Type or content-type', async () => {
+  it('should forward a request when header is Content-Type', async () => {
     const destinationUrl = 'https://approved.host/github-webhook/';
     const endpointId = encodeURIComponent(destinationUrl);
     const event: APIGatewayProxyWithLambdaAuthorizerEvent<any> = {

--- a/lambda/proxy.test.ts
+++ b/lambda/proxy.test.ts
@@ -117,6 +117,25 @@ describe('proxy', () => {
     expect(axios.post).toHaveBeenCalled();
   });
 
+  it('should forward a request if content-type header is Content-Type or content-type', async () => {
+    const destinationUrl = 'https://approved.host/github-webhook/';
+    const endpointId = encodeURIComponent(destinationUrl);
+    const event: APIGatewayProxyWithLambdaAuthorizerEvent<any> = {
+      ...baseEvent,
+      headers: {
+        ...baseEvent.headers,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(VALID_PUSH_PAYLOAD),
+      pathParameters: {
+        endpointId
+      }
+    };
+    const result = await handler(event);
+    expect(result).toEqual(expectedResponseObject);
+    expect(axios.post).toHaveBeenCalled();
+  });
+
   it('should not forward a request that does not come from an enterprise or managed user suffix', async () => {
     const destinationUrl = 'https://approved.host/github-webhook/';
     const endpointId = encodeURIComponent(destinationUrl);

--- a/lambda/proxy.test.ts
+++ b/lambda/proxy.test.ts
@@ -120,10 +120,14 @@ describe('proxy', () => {
   it('should forward a request if content-type header is Content-Type or content-type', async () => {
     const destinationUrl = 'https://approved.host/github-webhook/';
     const endpointId = encodeURIComponent(destinationUrl);
+
+    // create copy of baseEvent.headers without 'content-type' key
+    const { 'content-type': _, ...headers } = baseEvent.headers;
+
     const event: APIGatewayProxyWithLambdaAuthorizerEvent<any> = {
       ...baseEvent,
       headers: {
-        ...baseEvent.headers,
+        ...headers,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(VALID_PUSH_PAYLOAD),

--- a/lambda/proxy.test.ts
+++ b/lambda/proxy.test.ts
@@ -120,14 +120,11 @@ describe('proxy', () => {
   it('should forward a request if content-type header is Content-Type or content-type', async () => {
     const destinationUrl = 'https://approved.host/github-webhook/';
     const endpointId = encodeURIComponent(destinationUrl);
-
-    // create copy of baseEvent.headers without 'content-type' key
-    const { 'content-type': _, ...headers } = baseEvent.headers;
-
     const event: APIGatewayProxyWithLambdaAuthorizerEvent<any> = {
       ...baseEvent,
       headers: {
-        ...headers,
+        ...baseEvent.headers,
+        'content-type': undefined,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(VALID_PUSH_PAYLOAD),

--- a/lambda/schema.ts
+++ b/lambda/schema.ts
@@ -12,14 +12,19 @@ export const CONTENT_TYPES = {
 } as const;
 
 // headerSchema that supports either 'Content-Type' or 'content-type'
-export const headersSchema = z.object({
-  'content-type': z.string().optional(),
-  'Content-Type': z.string().optional()
-}).refine((headers) => {
-  return headers['content-type'] || headers['Content-Type'];
-}, {
-  message: 'Missing Content-Type header'
-});
+export const headersSchema = z
+  .object({
+    'content-type': z.string().optional(),
+    'Content-Type': z.string().optional()
+  })
+  .refine(
+    headers => {
+      return headers['content-type'] || headers['Content-Type'];
+    },
+    {
+      message: 'Missing Content-Type header'
+    }
+  );
 
 export const axiosErrorSchema = z.object({
   response: z.object({

--- a/lambda/schema.ts
+++ b/lambda/schema.ts
@@ -11,7 +11,6 @@ export const CONTENT_TYPES = {
   URL_ENCODED: 'application/x-www-form-urlencoded'
 } as const;
 
-// headerSchema that supports either 'Content-Type' or 'content-type'
 export const headersSchema = z
   .object({
     'content-type': z.string().optional(),

--- a/lambda/schema.ts
+++ b/lambda/schema.ts
@@ -11,8 +11,14 @@ export const CONTENT_TYPES = {
   URL_ENCODED: 'application/x-www-form-urlencoded'
 } as const;
 
+// headerSchema that supports either 'Content-Type' or 'content-type'
 export const headersSchema = z.object({
-  'content-type': z.nativeEnum(CONTENT_TYPES)
+  'content-type': z.string().optional(),
+  'Content-Type': z.string().optional()
+}).refine((headers) => {
+  return headers['content-type'] || headers['Content-Type'];
+}, {
+  message: 'Missing Content-Type header'
 });
 
 export const axiosErrorSchema = z.object({


### PR DESCRIPTION
### :pencil: Description
* Update schema to support `content-type` or `Content-Type` in the headers
* Update request parsing support `content-type` or `Content-Type` header keys

This change is necessary because GitHub very recently updated their webhook payloads and they've switched from 'content-type' to 'Content-Type'.

