### PR TITLE
refactor: make content type header case-insensitive

### DIFF
--- a/lambda/parse-request-body.ts
+++ b/lambda/parse-request-body.ts
@@ -17,7 +17,7 @@ import { bodySchema, CONTENT_TYPES, headersSchema } from './schema';
 
 export function parseRequestBody(body: string, headers: IncomingHttpHeaders) {
   const headersResult = headersSchema.parse(headers);
-  const contentType = headersResult['content-type'] || headersResult['Content-Type'];
+  const contentType = headersResult['content-type'];
   switch (contentType) {
     case CONTENT_TYPES.JSON:
       return JSON.parse(body);

--- a/lambda/proxy.test.ts
+++ b/lambda/proxy.test.ts
@@ -124,6 +124,7 @@ describe('proxy', () => {
       ...baseEvent,
       headers: {
         ...baseEvent.headers,
+        'content-type': undefined,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(VALID_PUSH_PAYLOAD),

--- a/lambda/proxy.test.ts
+++ b/lambda/proxy.test.ts
@@ -124,7 +124,6 @@ describe('proxy', () => {
       ...baseEvent,
       headers: {
         ...baseEvent.headers,
-        'content-type': undefined,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(VALID_PUSH_PAYLOAD),

--- a/lambda/proxy.test.ts
+++ b/lambda/proxy.test.ts
@@ -123,9 +123,9 @@ describe('proxy', () => {
     const event: APIGatewayProxyWithLambdaAuthorizerEvent<any> = {
       ...baseEvent,
       headers: {
-        ...baseEvent.headers,
-        'content-type': undefined,
-        'Content-Type': 'application/json'
+        Accept: '*/*',
+        'Content-Type': 'application/json',
+        Host: 'some-api.us-west-2.amazonaws.com'
       },
       body: JSON.stringify(VALID_PUSH_PAYLOAD),
       pathParameters: {

--- a/lambda/proxy.ts
+++ b/lambda/proxy.ts
@@ -61,6 +61,6 @@ export async function handler(event: APIGatewayProxyWithLambdaAuthorizerEvent<an
     }
 
     console.error('An unknown error occurred.', error);
-    return { statusCode: 500, body: 'Internal server error' };
+    return { statusCode: 500, body: `Internal server error: ${error}` };
   }
 }

--- a/lambda/schema.ts
+++ b/lambda/schema.ts
@@ -13,10 +13,13 @@ export const CONTENT_TYPES = {
 } as const;
 
 export const headersSchema = z
-  .object({
+  .preprocess(obj => {
+    if (obj && typeof obj == 'object') {
+      return mapKeys(obj, (_, key) => key.toLowerCase())
+    }
+  }, z.object({
     'content-type': z.nativeEnum(CONTENT_TYPES)
-  })
-  .transform(obj => mapKeys(obj, (_, key) => key.toLowerCase()));
+  }))
 
 export const axiosErrorSchema = z.object({
   response: z.object({

--- a/lambda/schema.ts
+++ b/lambda/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import mapKeys from 'lodash.mapkeys';
 
 export const urlSchema = z.string().url();
 
@@ -11,19 +12,9 @@ export const CONTENT_TYPES = {
   URL_ENCODED: 'application/x-www-form-urlencoded'
 } as const;
 
-export const headersSchema = z
-  .object({
-    'content-type': z.string().optional(),
-    'Content-Type': z.string().optional()
-  })
-  .refine(
-    headers => {
-      return headers['content-type'] || headers['Content-Type'];
-    },
-    {
-      message: 'Missing Content-Type header'
-    }
-  );
+export const headersSchema = z.object({
+  'content-type': z.nativeEnum(CONTENT_TYPES)
+}).transform(obj => mapKeys(obj, (_, key) => key.toLowerCase()));
 
 export const axiosErrorSchema = z.object({
   response: z.object({

--- a/lambda/schema.ts
+++ b/lambda/schema.ts
@@ -12,14 +12,16 @@ export const CONTENT_TYPES = {
   URL_ENCODED: 'application/x-www-form-urlencoded'
 } as const;
 
-export const headersSchema = z
-  .preprocess(obj => {
+export const headersSchema = z.preprocess(
+  obj => {
     if (obj && typeof obj == 'object') {
-      return mapKeys(obj, (_, key) => key.toLowerCase())
+      return mapKeys(obj, (_, key) => key.toLowerCase());
     }
-  }, z.object({
+  },
+  z.object({
     'content-type': z.nativeEnum(CONTENT_TYPES)
-  }))
+  })
+);
 
 export const axiosErrorSchema = z.object({
   response: z.object({

--- a/lambda/schema.ts
+++ b/lambda/schema.ts
@@ -12,9 +12,11 @@ export const CONTENT_TYPES = {
   URL_ENCODED: 'application/x-www-form-urlencoded'
 } as const;
 
-export const headersSchema = z.object({
-  'content-type': z.nativeEnum(CONTENT_TYPES)
-}).transform(obj => mapKeys(obj, (_, key) => key.toLowerCase()));
+export const headersSchema = z
+  .object({
+    'content-type': z.nativeEnum(CONTENT_TYPES)
+  })
+  .transform(obj => mapKeys(obj, (_, key) => key.toLowerCase()));
 
 export const axiosErrorSchema = z.object({
   response: z.object({

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@types/node": "20.1.1",
         "axios": "1.6.1",
+        "lodash.mapkeys": "4.6.0",
         "query-string": "7.1.3",
         "typescript": "5.2.2",
         "zod": "3.22.4"
@@ -17,6 +18,7 @@
         "@swc/jest": "0.2.29",
         "@types/aws-lambda": "8.10.107",
         "@types/jest": "29.5.8",
+        "@types/lodash.mapkeys": "4.6.9",
         "jest": "29.7.0",
         "prettier": "3.1.0"
       }
@@ -1561,6 +1563,21 @@
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.201",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.201.tgz",
+      "integrity": "sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.mapkeys": {
+      "version": "4.6.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mapkeys/-/lodash.mapkeys-4.6.9.tgz",
+      "integrity": "sha512-6/ERBCabeDI656LsV+oopLjdnJ/x1PCAE6kkkssH8e4i0K7Pw307noxHCbUc6cAVfTo9vx0Z+k3QZwy1IrUZcA==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
       }
     },
     "node_modules/@types/node": {
@@ -3632,6 +3649,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash.mapkeys": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mapkeys/-/lodash.mapkeys-4.6.0.tgz",
+      "integrity": "sha512-0Al+hxpYvONWtg+ZqHpa/GaVzxuN3V7Xeo2p+bY06EaK/n+Y9R7nBePPN2o1LxmL0TWQSwP8LYZ008/hc9JzhA=="
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@types/node": "20.1.1",
     "axios": "1.6.1",
+    "lodash.mapkeys": "4.6.0",
     "query-string": "7.1.3",
     "typescript": "5.2.2",
     "zod": "3.22.4"
@@ -19,6 +20,7 @@
     "@swc/jest": "0.2.29",
     "@types/aws-lambda": "8.10.107",
     "@types/jest": "29.5.8",
+    "@types/lodash.mapkeys": "4.6.9",
     "jest": "29.7.0",
     "prettier": "3.1.0"
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Follow-up to #134 to prevent the case of the content-type header from failing request forwarding.