### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/github-ip-ranges.yaml
+++ b/.github/workflows/github-ip-ranges.yaml
@@ -43,7 +43,7 @@ jobs:
             git add .
             git commit -m "fix: update github ip ranges"
             git push -u origin github-ip-range-update
-            echo "::set-output name=NEW_IP_RANGES::true"
+            echo "NEW_IP_RANGES=true" >> "$GITHUB_OUTPUT"
           fi
 
       - if: steps.ip-check.outputs.NEW_IP_RANGES == 'true'


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter