### PR TITLE
fix: drop redundant decodeURIComponent and repair urlencoded schema validation

### DIFF
--- a/lambda/parse-request-body.ts
+++ b/lambda/parse-request-body.ts
@@ -27,9 +27,20 @@ export function parseRequestBody(
         return JSON.parse(body);
       case CONTENT_TYPES.URL_ENCODED:
         const params = new URLSearchParams(body);
-        const payloadParam = params.get("payload");
-        const { payload } = bodySchema.parse(payloadParam);
-        return JSON.parse(decodeURIComponent(payload));
+        // bodySchema is `z.object({ payload: z.string() })`, so wrap the
+        // URLSearchParams.get() value (a `string | null`) in that shape
+        // before validating; passing the raw string failed schema parsing
+        // and broke every valid urlencoded webhook.
+        const { payload } = bodySchema.parse({
+          payload: params.get("payload"),
+        });
+        // URLSearchParams.get already URL-decodes the value, so `payload`
+        // is already the JSON string sent by GitHub. A second
+        // decodeURIComponent would throw URIError on any bare '%' that
+        // appears as literal user content (e.g. "30% threshold" in a PR
+        // title) and is unnecessary because GitHub webhooks are
+        // single-URL-encoded per the form-urlencoded spec.
+        return JSON.parse(payload);
     }
   } catch (error) {
     console.error(`Error parsing request body: ${error}`);

--- a/lambda/parse-request-body.ts
+++ b/lambda/parse-request-body.ts
@@ -27,19 +27,9 @@ export function parseRequestBody(
         return JSON.parse(body);
       case CONTENT_TYPES.URL_ENCODED:
         const params = new URLSearchParams(body);
-        // bodySchema is `z.object({ payload: z.string() })`, so wrap the
-        // URLSearchParams.get() value (a `string | null`) in that shape
-        // before validating; passing the raw string failed schema parsing
-        // and broke every valid urlencoded webhook.
         const { payload } = bodySchema.parse({
           payload: params.get("payload"),
         });
-        // URLSearchParams.get already URL-decodes the value, so `payload`
-        // is already the JSON string sent by GitHub. A second
-        // decodeURIComponent would throw URIError on any bare '%' that
-        // appears as literal user content (e.g. "30% threshold" in a PR
-        // title) and is unnecessary because GitHub webhooks are
-        // single-URL-encoded per the form-urlencoded spec.
         return JSON.parse(payload);
     }
   } catch (error) {

--- a/lambda/proxy.test.ts
+++ b/lambda/proxy.test.ts
@@ -321,10 +321,6 @@ describe("proxy", () => {
   });
 
   it("should forward a urlencoded webhook whose JSON contains literal '%' characters", async () => {
-    // Regression: bare '%' in PR titles / commit messages / comments (e.g.
-    // "30% threshold") previously caused parseRequestBody to throw URIError
-    // because of a redundant decodeURIComponent(payload) after
-    // URLSearchParams.get() had already URL-decoded the value.
     const payloadWithPercent = {
       ...VALID_PUSH_PAYLOAD,
       head_commit: {
@@ -353,11 +349,6 @@ describe("proxy", () => {
 });
 
 describe("parseRequestBody — urlencoded payloads with literal '%' characters", () => {
-  // The URL_ENCODED branch used to call JSON.parse(decodeURIComponent(payload)).
-  // URLSearchParams.get() already URL-decodes once, so the second decode would
-  // throw URIError: URI malformed on any string whose decoded form contains a
-  // bare '%' not followed by two hex digits — which is common in real PR
-  // titles, bodies, and comments. These tests pin the fix.
   const headers = { "content-type": "application/x-www-form-urlencoded" };
 
   const cases: Array<{ label: string; userContent: string }> = [
@@ -404,10 +395,6 @@ describe("parseRequestBody — urlencoded payloads with literal '%' characters",
   });
 
   it("correctly preserves valid percent-escapes (%20 → space) inside JSON string values", () => {
-    // A PR description that documents URL encoding by writing '%20' literally
-    // should reach the parsed JSON value as the literal string '%20', NOT as
-    // a decoded space. URLSearchParams.get() decodes the OUTER encoding once;
-    // characters inside the JSON string value are preserved verbatim.
     const literalText = "encoded as %20 example";
     const json = JSON.stringify({ comment: { body: literalText } });
     const body = "payload=" + encodeURIComponent(json);

--- a/lambda/proxy.test.ts
+++ b/lambda/proxy.test.ts
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import { handler } from "./proxy";
+import { parseRequestBody } from "./parse-request-body";
 import type { AxiosRequestHeaders, AxiosResponse } from "axios";
 import { readFileSync } from "fs";
 import { Agent } from "https";
@@ -317,5 +318,100 @@ describe("proxy", () => {
       headers: { response: "headers" },
     });
     expect(axiosPostMock).toHaveBeenCalled();
+  });
+
+  it("should forward a urlencoded webhook whose JSON contains literal '%' characters", async () => {
+    // Regression: bare '%' in PR titles / commit messages / comments (e.g.
+    // "30% threshold") previously caused parseRequestBody to throw URIError
+    // because of a redundant decodeURIComponent(payload) after
+    // URLSearchParams.get() had already URL-decoded the value.
+    const payloadWithPercent = {
+      ...VALID_PUSH_PAYLOAD,
+      head_commit: {
+        ...(VALID_PUSH_PAYLOAD as any).head_commit,
+        message:
+          "Roll out 30% threshold; reference %USERPROFILE% on Windows; WHERE x LIKE '%foo%'",
+      },
+    };
+    const urlencodedBody =
+      "payload=" + encodeURIComponent(JSON.stringify(payloadWithPercent));
+    const destinationUrl = "https://approved.host/github-webhook/";
+    const endpointId = encodeURIComponent(destinationUrl);
+    const event: APIGatewayProxyWithLambdaAuthorizerEvent<any> = {
+      ...baseEvent,
+      headers: {
+        ...baseEvent.headers,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: urlencodedBody,
+      pathParameters: { endpointId },
+    };
+    const result = await handler(event);
+    expect(result).toEqual(expectedResponseObject);
+    expect(axiosPostMock).toHaveBeenCalled();
+  });
+});
+
+describe("parseRequestBody — urlencoded payloads with literal '%' characters", () => {
+  // The URL_ENCODED branch used to call JSON.parse(decodeURIComponent(payload)).
+  // URLSearchParams.get() already URL-decodes once, so the second decode would
+  // throw URIError: URI malformed on any string whose decoded form contains a
+  // bare '%' not followed by two hex digits — which is common in real PR
+  // titles, bodies, and comments. These tests pin the fix.
+  const headers = { "content-type": "application/x-www-form-urlencoded" };
+
+  const cases: Array<{ label: string; userContent: string }> = [
+    { label: "percentage in PR title", userContent: "30% threshold rollout" },
+    { label: "trailing percent", userContent: "rate: 5%" },
+    {
+      label: "Windows env var reference",
+      userContent: "set %USERPROFILE% to ~",
+    },
+    {
+      label: "SQL LIKE wildcard",
+      userContent: "WHERE name LIKE '%foo%' AND status = 1",
+    },
+    {
+      label: "C-style format string",
+      userContent: 'printf("%s\\n", val);',
+    },
+    { label: "Go format verb", userContent: 'log.Printf("%v", obj)' },
+    {
+      label: "bare % followed by non-hex",
+      userContent: "look here: %g and %h",
+    },
+  ];
+
+  for (const c of cases) {
+    it(`parses a webhook whose JSON contains literal '%' (${c.label})`, () => {
+      const json = JSON.stringify({
+        action: "opened",
+        pull_request: { title: c.userContent, body: c.userContent },
+      });
+      const body = "payload=" + encodeURIComponent(json);
+      const result = parseRequestBody(body, headers);
+      expect(result).toBeDefined();
+      expect((result as any).pull_request.title).toBe(c.userContent);
+    });
+  }
+
+  it("still parses payloads with no '%' characters (control)", () => {
+    const json = JSON.stringify({ action: "opened", number: 42 });
+    const body = "payload=" + encodeURIComponent(json);
+    const result = parseRequestBody(body, headers);
+    expect(result).toBeDefined();
+    expect((result as any).number).toBe(42);
+  });
+
+  it("correctly preserves valid percent-escapes (%20 → space) inside JSON string values", () => {
+    // A PR description that documents URL encoding by writing '%20' literally
+    // should reach the parsed JSON value as the literal string '%20', NOT as
+    // a decoded space. URLSearchParams.get() decodes the OUTER encoding once;
+    // characters inside the JSON string value are preserved verbatim.
+    const literalText = "encoded as %20 example";
+    const json = JSON.stringify({ comment: { body: literalText } });
+    const body = "payload=" + encodeURIComponent(json);
+    const result = parseRequestBody(body, headers);
+    expect((result as any).comment.body).toBe(literalText);
   });
 });


### PR DESCRIPTION
## Summary

Fixes two bugs in `lambda/parse-request-body.ts` that together break every valid `application/x-www-form-urlencoded` GitHub webhook. Both bugs were introduced by the recent `094cda1` (`feat(repo): switch to bun`) refactor that introduced `URLSearchParams`.

## Bug 1 — schema is parsed against the wrong shape

```ts
const params = new URLSearchParams(body);
const payloadParam = params.get("payload");        // string | null
const { payload } = bodySchema.parse(payloadParam); // bodySchema is z.object({ payload: z.string() })
```

`URLSearchParams.get` returns the value of the `payload=` field as a `string | null`. `bodySchema` is declared as `z.object({ payload: z.string() })`, so zod throws `Invalid input: expected object, received string` and `parseRequestBody` returns `undefined`. The handler then 403s every valid urlencoded GitHub webhook.

The existing fixture-based test (`fixtures/invalid-payload-urlencoded.txt`) hides this because the fixture is deliberately invalid and the test only checks that invalid payloads are *rejected* — it does not exercise a valid urlencoded payload's success path.

## Bug 2 — redundant `decodeURIComponent` throws on literal `%`

```ts
return JSON.parse(decodeURIComponent(payload));
```

`URLSearchParams.get` already URL-decodes the value once (`%7B` → `{`, etc.). Calling `decodeURIComponent` a *second* time on the already-decoded JSON string throws `URIError: URI malformed` whenever the JSON contains a bare `%` that doesn't begin a valid `%XX` escape — extremely common in real user content:

| Pattern | Example |
|---|---|
| Percentage in PR title / commit message | `30% threshold rollout`, `100% complete` |
| Trailing `%` | `rate: 5%` |
| Windows env-var reference | `set %USERPROFILE% to ~`, `%PATH%` |
| SQL `LIKE` wildcard | `WHERE name LIKE '%foo%'` |
| C / Go format verbs | `printf("%s\n", val)`, `log.Printf("%v", obj)` |
| Bare `%` followed by non-hex | `look here: %g and %h` |

GitHub sends webhook bodies single-URL-encoded per the form-urlencoded spec; the second decode was never needed for correct decoding of real traffic.

## Fix

```diff
       case CONTENT_TYPES.URL_ENCODED:
         const params = new URLSearchParams(body);
-        const payloadParam = params.get("payload");
-        const { payload } = bodySchema.parse(payloadParam);
-        return JSON.parse(decodeURIComponent(payload));
+        const { payload } = bodySchema.parse({
+          payload: params.get("payload"),
+        });
+        return JSON.parse(payload);
```

1. Wraps `params.get("payload")` into the `{ payload: string }` shape `bodySchema` expects, so validation actually runs.
2. Drops the redundant `decodeURIComponent` so literal `%` characters in user content no longer crash the parse.

## Tests

Adds 9 new test cases in `lambda/proxy.test.ts`:

- One end-to-end test through the `handler` driving a urlencoded webhook whose JSON contains literal `%` characters (multiple patterns combined).
- A new `describe("parseRequestBody — urlencoded payloads with literal '%' characters", …)` block exercising `parseRequestBody` directly for each of the user-content patterns listed in the table above, plus:
  - A **control** with no special characters to confirm normal payloads still parse.
  - A **`%20` preservation test** confirming that literal `%20` in a JSON string value is preserved verbatim (not re-decoded to a space), which is the correct semantic now that the outer `URLSearchParams.get` is the sole decode pass.

Local run: `22 pass, 0 fail` (12 existing + 10 new).

## Backwards-compatibility analysis

The only scenario where removing the second decode would change behavior is a hypothetical client that **double-URL-encodes** the body. GitHub never does this. Even if it happened, the lambda only inspects `enterprise.slug` and `sender.login` for the routing/auth decision (both are GitHub identifier strings that cannot contain `%`), and the raw original `body` is forwarded byte-for-byte to the destination via `axios.post(url, body, …)` — so the routing decision and forwarded payload are unchanged in that edge case.

## Notes

- No deps changed.
- `bun run format-check` clean.
- `bun test` passes 22/22.